### PR TITLE
Changed frame values to int

### DIFF
--- a/ActionLoader.py
+++ b/ActionLoader.py
@@ -132,10 +132,10 @@ def update_rangemode(self, context):
         if ActiveAction.get("frame_start") == None:
             pass
         else:
-            context.scene.frame_preview_start = ActiveAction["frame_start"]
-            context.scene.frame_preview_end = ActiveAction["frame_end"]
-            context.scene.frame_start = ActiveAction["frame_start"]
-            context.scene.frame_end = ActiveAction["frame_end"]  
+            context.scene.frame_preview_start = int(ActiveAction["frame_start"])
+            context.scene.frame_preview_end = int(ActiveAction["frame_end"])
+            context.scene.frame_start = int(ActiveAction["frame_start"])
+            context.scene.frame_end = int(ActiveAction["frame_end"])
     elif context.scene.actionloader_rangemode == "1":
         if ActiveAction == None:
             pass


### PR DESCRIPTION
Hi! This is my first ever contribution to any code, so forgive me if it is wrong. In newer versions of blender the frame values for  setting custom frame range are expected to be int not float, so I thought it would be nice to fix this, as the current version of the addon is not working for this function.